### PR TITLE
Change the working directory of containers to a user-writable path

### DIFF
--- a/realm-object-server/templates/core-services.yaml
+++ b/realm-object-server/templates/core-services.yaml
@@ -31,7 +31,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - node
-            - ./dist/KubernetesCoreServices.js
+            - /usr/local/lib/node_modules/realm-object-server/dist/KubernetesCoreServices.js
+          workingDir: /data
           env:
             - name: PUBLIC_KEY_PATH
               value: /config/public.pem

--- a/realm-object-server/templates/sync-workers.yaml
+++ b/realm-object-server/templates/sync-workers.yaml
@@ -125,7 +125,8 @@ spec:
               value: {{ .logLevel | default $values.sync.logLevel }}
           command:
             - node
-            - ./dist/KubernetesSyncWorkerGroup.js
+            - /usr/local/lib/node_modules/realm-object-server/dist/KubernetesSyncWorkerGroup.js
+          workingDir: /data
           ports:
             - name: internal
               containerPort: 9081


### PR DESCRIPTION
This allows the containers to run as a non-root user. Fixes [ROS-94](https://jira.mongodb.org/browse/ROS-94).