### PR TITLE
Remove subsets in the sync worker Endpoints template

### DIFF
--- a/realm-object-server/templates/sync-workers.yaml
+++ b/realm-object-server/templates/sync-workers.yaml
@@ -190,7 +190,6 @@ metadata:
     group: {{ .name }}
   annotations:
     sync.realm.io/group: {{ .name }}
-subsets: []
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The empty subsets array causes the helm operator to constantly try to reconcile the Endpoints object as soon as it detects that the sync worker has patched it to insert its own subsets.